### PR TITLE
selections: Update for pkgsets

### DIFF
--- a/crates/installer/src/selections.rs
+++ b/crates/installer/src/selections.rs
@@ -133,7 +133,7 @@ mod tests {
         let pkgs = manager
             .selections_with(["develop"])
             .expect("Needed empty set of base selections");
-        assert_eq!(pkgs_partial.len(), 42);
-        assert_eq!(pkgs.len(), 46);
+        assert_eq!(pkgs_partial.len(), 44);
+        assert_eq!(pkgs.len(), 48);
     }
 }

--- a/lichen_cli/src/main.rs
+++ b/lichen_cli/src/main.rs
@@ -245,6 +245,7 @@ fn main() -> color_eyre::Result<()> {
     // Test selection management, force GNOME
     let selections = selections::Manager::new().with_groups([
         Group::from_str(include_str!("../../selections/base.json"))?,
+        Group::from_str(include_str!("../../selections/base-desktop.json"))?,
         Group::from_str(include_str!("../../selections/cosmic.json"))?,
         Group::from_str(include_str!("../../selections/develop.json"))?,
         Group::from_str(include_str!("../../selections/gnome.json"))?,

--- a/selections/base-desktop.json
+++ b/selections/base-desktop.json
@@ -1,0 +1,12 @@
+{
+  "name": "base-desktop",
+  "summary": "Common desktop components",
+  "description": "Common desktop components",
+  "depends": [
+    "base"
+  ],
+  "required": [
+    "pkgset-aeryn-base-desktop",
+    "zram-generator-defaults"
+  ]
+}

--- a/selections/base.json
+++ b/selections/base.json
@@ -37,13 +37,15 @@
     "iproute2",
     "hyperv-daemons",
     "pciutils",
+    "pkgset-aeryn-base",
+    "pkgset-aeryn-utilities",
+    "pkgset-aeryn-virtual",
     "qemu-guest-agent",
     "usbutils",
     "shadow",
     "spice-vdagent",
     "systemd",
     "tzdata",
-    "util-linux",
-    "zram-generator-defaults"
+    "util-linux"
   ]
 }

--- a/selections/cosmic.json
+++ b/selections/cosmic.json
@@ -3,7 +3,7 @@
   "summary": "COSMIC Desktop",
   "description": "Warning: Provided as an alpha preview",
   "depends": [
-    "base"
+    "base-desktop"
   ],
   "required": [
     "cosmic-applets",
@@ -35,6 +35,8 @@
     "font-noto",
     "font-noto-emoji",
     "liberation-fonts-ttf",
+    "pkgset-aeryn-cosmic-minimal",
+    "pkgset-aeryn-cosmic-recommended",
     "serpent-artwork",
     "sysbinary(plymouthd)",
     "xdg-desktop-portal-cosmic",

--- a/selections/gnome.json
+++ b/selections/gnome.json
@@ -3,7 +3,7 @@
   "summary": "GNOME Desktop",
   "description": "Recommended for most users",
   "depends": [
-    "base"
+    "base-desktop"
   ],
   "required": [
     "binary(celluloid)",
@@ -32,6 +32,8 @@
     "gnome-backgrounds",
     "liberation-fonts-ttf",
     "loupe",
+    "pkgset-aeryn-gnome-minimal",
+    "pkgset-aeryn-gnome-recommended",
     "serpent-gnome-defaults",
     "sysbinary(gdm)",
     "sysbinary(plymouthd)"


### PR DESCRIPTION
Update the package selections to install pkgsets. For minimal disruption the old selections are not removed.

Depends on AerynOS/recipes#920