### PR TITLE
feat: added internet warning before installation

### DIFF
--- a/lichen_cli/src/main.rs
+++ b/lichen_cli/src/main.rs
@@ -206,6 +206,18 @@ fn main() -> color_eyre::Result<()> {
     let euid = unsafe { geteuid() };
     ensure!(euid == 0, "lichen must be run as root. Re-run with sudo.");
 
+    let internet_warning = indoc! {"
+        An active internet connection is required to install AerynOS.
+
+        The installer will attempt to download all the latest required packages from the AerynOS repository. 
+        Please ensure your system is connected to the internet before proceeding, otherwise installation will fail.
+    "};
+    cliclack::log::warning(format!(
+        "{}\n{}\n",
+        style("Internet Requirement:").bold(),
+        internet_warning
+    ))?;
+
     let partition_detection_warning = indoc! {"
         This iteration of the installer REQUIRES you to have pre-created GPT partitions.
 


### PR DESCRIPTION
## Add Internet Connection Reminder to Lichen Installer

### Summary

This PR adds a short message to the Lichen installer reminding users to ensure they are connected to the internet before proceeding with the installation of AerynOS. This helps avoid installation failures due to missing packages from the repository.

### Changes

* Added a clear message early in the Lichen installation process to inform users that an active internet connection is required.

### Motivation

Lichen previously proceeded through multiple installation steps (e.g., setting locale, selecting drives) before ultimately failing if no internet connection was available. This improvement provides better UX by informing the user upfront, avoiding wasted time and confusion.

### Closes #73 


