### PR TITLE
fix: Actually install Plasma

### DIFF
--- a/selections/plasma-sddm.json
+++ b/selections/plasma-sddm.json
@@ -5,7 +5,7 @@
   "display": true,
   "priority": 15,
   "depends": [
-    "base-desktop"
+    "plasma-shared"
   ],
   "required": [
     "binary(sddm)",


### PR DESCRIPTION
People who choose Plasma from the installer probably want Plasma to get installed (citation needed).