### PR TITLE
desktop: Add scx-scheds

### DIFF
--- a/selections/base-desktop.json
+++ b/selections/base-desktop.json
@@ -12,6 +12,7 @@
     "font-noto",
     "font-noto-emoji",
     "liberation-fonts-ttf",
+    "scx-scheds",
     "sysbinary(plymouthd)",
     "pkgset-aeryn-base-desktop",
     "zram-generator-defaults"


### PR DESCRIPTION
I have been testing scx-scheds for a while now and think that it's a worthwhile package to install by default. By default it uses the scx-flash scheduler, which is "designed for multimedia and real-time audio processing workloads". This scheduler does an excellent job of avoiding audio hitching and keeping GUI interfaces responsive under heavy system load in my testing, which IMO makes it a solid out-of-the-box default.