### PR TITLE
lichen: Dynamically load selections at build-time

### DIFF
--- a/lichen_cli/Cargo.toml
+++ b/lichen_cli/Cargo.toml
@@ -2,6 +2,7 @@
 name = "lichen_cli"
 version = "0.1.0"
 edition = "2021"
+build = "build.rs"
 
 [dependencies]
 color-eyre.workspace = true

--- a/lichen_cli/build.rs
+++ b/lichen_cli/build.rs
@@ -1,0 +1,43 @@
+use std::{
+    env,
+    error::Error,
+    fs::{self, File},
+    io::Write,
+    path::Path,
+};
+
+const SELECTIONS_DIR: &str = "../selections";
+
+fn main() -> Result<(), Box<dyn Error>> {
+    println!("cargo::rerun-if-changed={SELECTIONS_DIR}");
+
+    let out_dir = env::var("OUT_DIR")?;
+    let dest_path = Path::new(&out_dir).join("selections.rs");
+
+    let mut selections = File::create(&dest_path)?;
+
+    writeln!(&mut selections, r##"macro_rules! selections {{"##,)?;
+    writeln!(&mut selections, r##"() => {{["##,)?;
+    for f in fs::read_dir(SELECTIONS_DIR)? {
+        let f = f?;
+
+        if !f.file_type()?.is_file() {
+            continue;
+        }
+
+        if !f.file_name().to_str().unwrap().ends_with(".json") {
+            continue;
+        }
+
+        writeln!(
+            &mut selections,
+            r##"Group::from_str(include_str!("../{name}"))?,"##,
+            name = f.path().display(),
+        )?;
+    }
+
+    writeln!(&mut selections, r##"]}};"##,)?;
+    writeln!(&mut selections, r##"}}"##,)?;
+
+    Ok(())
+}

--- a/lichen_cli/src/main.rs
+++ b/lichen_cli/src/main.rs
@@ -24,6 +24,8 @@ use installer::{
 };
 use nix::libc::geteuid;
 
+include!(concat!(env!("OUT_DIR"), "/selections.rs"));
+
 #[derive(Debug)]
 struct CliContext {
     root: PathBuf,
@@ -244,21 +246,8 @@ fn main() -> color_eyre::Result<()> {
 
     cliclack::intro(style("Install AerynOS").bold())?;
 
-    // Test selection management, force GNOME
-    let selections = selections::Manager::new().with_groups([
-        Group::from_str(include_str!("../../selections/base.json"))?,
-        Group::from_str(include_str!("../../selections/base-desktop.json"))?,
-        Group::from_str(include_str!("../../selections/cosmic.json"))?,
-        Group::from_str(include_str!("../../selections/develop.json"))?,
-        Group::from_str(include_str!("../../selections/gnome.json"))?,
-        Group::from_str(include_str!("../../selections/kernel-common.json"))?,
-        Group::from_str(include_str!("../../selections/kernel-desktop.json"))?,
-        Group::from_str(include_str!("../../selections/plasma-shared.json"))?,
-        Group::from_str(include_str!("../../selections/plasma-sddm.json"))?,
-        Group::from_str(include_str!("../../selections/plasma-plm.json"))?,
-        Group::from_str(include_str!("../../selections/sway.json"))?,
-        Group::from_str(include_str!("../../selections/server.json"))?,
-    ]);
+    // Test selection management
+    let selections = selections::Manager::new().with_groups(selections!());
 
     let desktops = selections.groups().filter(|g| g.display).collect::<Vec<_>>();
 


### PR DESCRIPTION
> Instead of manually adding an entry for every selection generate a macro at build-time using build.rs and then use that.
>
> I adapted this from what I think was a fairly old example on stackoverflow so I think the Rust code is likely not idiomatic anymore. I can't figure out how to run clippy on build.rs however.

Contributed by Reilly Brogan <reilly@reillybrogan.com>

Supersedes #83 